### PR TITLE
Revert "vendor_prop: Set fluencetype to none"

### DIFF
--- a/vendor_prop.mk
+++ b/vendor_prop.mk
@@ -93,7 +93,7 @@ PRODUCT_PROPERTY_OVERRIDES += \
 # Audio fluence
 # fluencetype can be "fluence" or "fluencepro" or "none"
 PRODUCT_PROPERTY_OVERRIDES += \
-    ro.vendor.audio.sdk.fluencetype=none \
+    ro.vendor.audio.sdk.fluencetype=fluence \
     persist.vendor.audio.fluence.speaker=true \
     persist.vendor.audio.fluence.voicecall=true\
     persist.vendor.audio.fluence.voicerec=false


### PR DESCRIPTION
If we are setting it to none, then voice call are not really working.
The voice is too low.

This reverts commit 869ed53675973b6f114e4b4a1f8ba5eaf39e14d9.